### PR TITLE
add getArtifactContentStream method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ bamboo.getArtifactContent("PROJECT_KEY-PLAN_KEY/BUILD_NUMBER", "artifact", funct
 });
 ```
 
+#### bamboo.getArtifactContentStream(buildDetails, artifactName)
+
+Get a stream of the content of an artifact associated to a build.
+
+```javascript
+var stream = bamboo.getArtifactContentStream("PROJECT_KEY-PLAN_KEY/BUILD_NUMBER", "artifact");
+
+stream.on('error', function (error) {
+    console.log(error);
+});
+
+stream.on('data', function (data) {
+  console.log(data);
+});
+```
+
 #### bamboo.getAllPlans(params, callback, currentPlans)
 
 Get list of plans, key and names available.

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -10,7 +10,8 @@ module.exports = function(host, username, password) {
     "use strict";
 
     var request = require('request'),
-        _ = require('underscore');
+        _ = require('underscore'),
+        stream = require('stream');
 
     /**
      * Function defining a Bamboo instance
@@ -300,6 +301,37 @@ module.exports = function(host, username, password) {
 
             callback(null, body.toString("utf-8", 0));
         });
+    };
+
+    /**
+     * Returns a stream of the content of an artifact associated to a build
+     *
+     * @param {String} buildDetails - Bamboo plan key + build number, like "PROJECT_KEY-PLAN_KEY/BUILD_NUMBER"
+     * @param {String} artifactName - Artifact name
+     * @returns {stream.Readable} stream
+     */
+    Bamboo.prototype.getArtifactContentStream = function(buildDetails, artifactName) {
+        var artifactUri = this.host + "/browse/" + buildDetails + "/artifact/shared/" + artifactName + "/" + artifactName;
+
+        var out = new stream.PassThrough();
+        var req = request({ uri: artifactUri });
+
+        req.on('error', function (err) {
+          out.emit('error', error);
+        });
+
+        req.on('response', function (res) {
+            var errors = checkErrors(null, res);
+
+            if (errors) {
+                stream.emit('error', errors);
+                return;
+            }
+
+            res.pipe(out);
+        });
+
+        return out;
     };
 
     /**

--- a/test/bambooTest.js
+++ b/test/bambooTest.js
@@ -387,6 +387,26 @@ describe("bamboo.getArtifactContent", function() {
     });
 });
 
+describe("bamboo.getArtifactContentStream", function() {
+    "use strict";
+
+    it("returns the latest successful build number", function(done) {
+        nock(baseTestUrl)
+            .get('/browse/myPrj-myPlan-234/artifact/shared/name1/name1')
+            .reply(200, "AAA");
+
+        var bamboo = new Bamboo(baseTestUrl);
+        var stream = bamboo.getArtifactContentStream("myPrj-myPlan-234", "name1");
+
+        stream.on('error', done);
+        stream.on('readable', function () {
+          stream.read(3).toString().should.equal("AAA");
+          done();
+        });
+    });
+});
+
+
 describe("bamboo.getJiraIssuesFromBuild", function() {
     "use strict";
 


### PR DESCRIPTION
This patch adds a method to retrieve an artifacts contents as a stream, instead of a buffer. Useful for big artifacts.