### PR TITLE
Added support in searching bamboo's entities

### DIFF
--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -440,6 +440,51 @@ module.exports = function(host, username, password) {
         )
     }
 
+  /**
+     * Performs search on Bamboo's resources
+     * In order to provide suitable params, Please follow https://docs.atlassian.com/bamboo/REST/5.5.0/#d2e923
+     * @param entityToSearch    string - The entity to search (currently, one of [users, authors, plans, branches, projects, versions])
+     * @param optionsQuery      object - search parameters to provide as described in link above, represented as object
+     * @example of optionsQuery
+     *  {
+     *      masterPlanKey: "KEY",
+     *      IncludeMasterBranch: false
+     *  }
+     * @param callback - callback(error) on error, callback(null, result) else
+     *
+     * @return [object]  array of found entities
+     *
+     */
+    Bamboo.prototype.search = function (entityToSearch, params, callback) {
+
+        var self = this,
+            planUri = self.host + "/rest/api/latest/search/" + entityToSearch + ".json";
+
+        request({
+            uri: planUri,
+            qs: params
+        }, function (error, response, body) {
+
+            // keys in body, as defined in bamboo's apidoc
+            var resultsKey = "searchResults",
+                entityKey = "searchEntity";
+
+            if (error) {
+                return callback(error);
+            }
+
+            try {
+                var body = JSON.parse(body.toString("utf-8", 0));
+                var searchResults = body[resultsKey]; // as defined in doc
+
+                return callback(null, _.pluck(searchResults, entityKey));
+
+            } catch (err) {
+                callback(err);
+            }
+        });
+    }
+
     /**
      * Method checks for errors in error and server response
      * Additionally parsing response body and checking if it contain any results

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -441,7 +441,7 @@ module.exports = function(host, username, password) {
     }
 
   /**
-     * Performs search on Bamboo's resources
+     * Performs search on Bamboo's entities
      * In order to provide suitable params, Please follow https://docs.atlassian.com/bamboo/REST/5.5.0/#d2e923
      * @param entityToSearch    string - The entity to search (currently, one of [users, authors, plans, branches, projects, versions])
      * @param optionsQuery      object - search parameters to provide as described in link above, represented as object


### PR DESCRIPTION
Hi, 

Bamboo provides ability to query their entities via API. (see reference [here](https://docs.atlassian.com/bamboo/REST/5.5.0/#d2e923))

Currently, the following entities can be queried as described in [doc](https://docs.atlassian.com/bamboo/REST/5.5.0/#d2e923):

- users
- authors
- branches
- projects
- versions

Some of the entities has mandatory parameters, mentioned this fact in doc.
