### PR TITLE
send params to buildPlan only if necessary, new response handler

### DIFF
--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -404,14 +404,14 @@ module.exports = function(host, username, password) {
      * @param callback
      */
     Bamboo.prototype.buildPlan = function(buildDetails, params, callback) {
+        var errorStatusCodes = [400, 401, 404, 415]; // as described in https://docs.atlassian.com/bamboo/REST/5.9.1-SNAPSHOT/#d2e620, 500 raises the error argument
         var self = this,
             planUri = self.host + "/rest/api/latest/queue/" + buildDetails + ".json?os_authType=basic";
+
         request.post(
             planUri,
-            {form: params},
-            function(error, response, body) {
-                callback(checkErrors(error, response), body.toString("utf-8", 0));
-            }
+            (!params || _.isEmpty(params)) ? {} : {form: params},
+            handleResponse(errorStatusCodes, callback)
         )
     }
 
@@ -529,6 +529,35 @@ module.exports = function(host, username, password) {
         }
 
         return false;
+    }
+    
+    /**
+     * According to bamboo's doc, each RestAPI resource has specific error status codes available.
+     * For some error status codes (such as 401 Unauthorized), error object is empty.
+     * If response's status code is one of the given status codes, the given callback will be called with error.
+     *
+     * Given error status codes and desired callback, the function will generate a response handler to request which will behave as described above.
+     *
+     * @param errorStatusCodes  {[Number]}  Array of possible error status codes (each request has specific possible error status codes evailable)
+     * @param callback          If response's status code is one of the possible error status codes or error object is not null - error is raised,
+     *                          else - callback is called with the body
+     *
+     * @return - Handler as follows:
+     *  @param error             {Error}     Error raised from request if exist
+     *  @param response          {Object}    The result response object of the request sent
+     *  @param body              {Object}    The result body object of the request sent
+     */
+    function generateResponseHandler(errorStatusCodes, callback) {
+        return function handler(error, response, body) {
+            if (error) {
+                return callback(error);
+            }
+            if (_.contains(errorStatusCodes, response.statusCode)) { // if error contains
+                return callback(body.toString("utf-8", 0));
+            }
+            // Possible errors handled and not found, call with body as result
+            callback(error, body.toString("utf-8", 0));
+        }
     }
 
     return new Bamboo(host, username, password);


### PR DESCRIPTION
Hi, 

I've noticed that sending extra body parameters to request might damage the error message, so validated the extra params are not empty before adding them.

Also, as described in doc, each api call has specific response status codes. 
For some status codes, the error status code returned as the body, and the error object is empty. 

To solve this case, added a response handler generator, which accepts array of possible error status codes and a desired callback, and generates a response handler for the request.

Last thing is a request - can you please increase the version and publish it to npm?

Thanks in advance,
Reuven 